### PR TITLE
docs: 修复 README 中失效的 Star History 图表链接

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -187,7 +187,7 @@ Issues and Pull Requests welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## 📈 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=prehisle/relay-pulse&type=Date)](https://star-history.com/#prehisle/relay-pulse&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=prehisle/relay-pulse&type=Date)](https://star-history.dera.page/#prehisle/relay-pulse&Date)
 
 ## ⚠️ Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ curl -X POST http://localhost:8080/api/status/batch \
 
 ## 📈 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=prehisle/relay-pulse&type=Date)](https://star-history.com/#prehisle/relay-pulse&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=prehisle/relay-pulse&type=Date)](https://star-history.dera.page/#prehisle/relay-pulse&Date)
 
 ## ⚠️ 免责声明
 


### PR DESCRIPTION
README 中的 Star History 图表目前已经失效，无法正常渲染，原因是上游图表服务受 GitHub stargazer API 限制而中断。

本次变更将中英文两份 README 的 Star History 图表链接切换到可正常工作的新地址（star-history.dera.page），图表与跳转链接均已一并更新。修复后图表即可重新展示项目历史星标趋势。